### PR TITLE
More visible focus highlight

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,3 +116,11 @@ table {
   font-family: inherit;
   margin: 0;
 }
+
+input:focus {
+  outline: 2px solid #007bff;
+}
+
+select:focus {
+  outline: 2px solid #007bff;
+}


### PR DESCRIPTION
Before when we navigated the page using the keyboard because the default focus highlight color was black and with the new nav bar being a darker color you could not see if the dropdowns were in current focus. All i did was add some css to change the highlight color to a more visible blue