### PR TITLE
Remove type=radio from select elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
       <div class="form-input-flex">
         <label for="dept-filter" class="form-input-label">Department:</label>
         <select
-          type="radio"
           name="department"
           id="dept-filter"
           class="form-input-selector"
@@ -23,12 +22,7 @@
 
       <div class="form-input-flex">
         <label for="startTimes" class="form-input-label">Start Time: </label>
-        <select
-          type="radio"
-          name="startTimes"
-          id="startTimes"
-          class="form-input-selector"
-        >
+        <select name="startTimes" id="startTimes" class="form-input-selector">
           <option value="No Specific Time">No Specific Time</option>
           <option value="07:00:00">07:00:00</option>
           <option value="08:00:00">08:00:00</option>


### PR DESCRIPTION
"type" is not a valid attribute on select elements, so this change removes the attribute.